### PR TITLE
Fix: Duplicate Nickname in User Fixture Violates Unique Constraint

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,10 +181,10 @@ async def users_with_same_role_50_users(db_session):
     users = []
     for _ in range(50):
         user_data = {
-            "nickname": fake.user_name(),
+            "nickname": fake.unique.user_name(),
             "first_name": fake.first_name(),
             "last_name": fake.last_name(),
-            "email": fake.email(),
+            "email": fake.unique.email(),
             "hashed_password": fake.password(),
             "role": UserRole.AUTHENTICATED,
             "email_verified": False,
@@ -194,6 +194,7 @@ async def users_with_same_role_50_users(db_session):
         db_session.add(user)
         users.append(user)
     await db_session.commit()
+    fake.unique.clear() 
     return users
 
 @pytest.fixture


### PR DESCRIPTION
Used faker.unique to ensure all generated nicknames are unique in the fixture.

🔧 Fix (in tests/conftest.py): #3 
Changed this block inside users_with_same_role_50_users:

"nickname": fake.user_name(),
To this:
"nickname": fake.unique.user_name(),
✅ This ensures every user in the 50-user bulk insert has a unique nickname, preventing database constraint violations.