### PR TITLE
Password validation and tests added

### DIFF
--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -54,6 +54,20 @@ class UserCreate(UserBase):
     email: EmailStr = Field(..., example="john.doe@example.com")
     password: str = Field(..., example="Secure*1234")
 
+    @validator("password")
+    def validate_password(cls, v):
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters long.")
+        if not re.search(r"[A-Z]", v):
+            raise ValueError("Password must contain at least one uppercase letter.")
+        if not re.search(r"[a-z]", v):
+            raise ValueError("Password must contain at least one lowercase letter.")
+        if not re.search(r"[0-9]", v):
+            raise ValueError("Password must contain at least one digit.")
+        if not re.search(r"[\W_]", v):
+            raise ValueError("Password must contain at least one special character.")
+        return v
+
 class UserUpdate(UserBase):
     email: Optional[EmailStr] = Field(None, example="john.doe@example.com")
     nickname: Optional[str] = Field(None, example="john_doe123")

--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -67,3 +67,28 @@ def test_user_base_invalid_email(user_base_data_invalid):
     
     assert "value is not a valid email address" in str(exc_info.value)
     assert "john.doe.example.com" in str(exc_info.value)
+
+@pytest.mark.parametrize("password", [
+    "ValidPass123!",
+    "Abcdef1#",
+    "A1b2c3d4*",
+    "Strong$Pass9"
+])
+def test_user_create_password_valid(password, user_base_data):
+    user_data = {**user_base_data, "password": password}
+    user = UserCreate(**user_data)
+    assert user.password == password
+
+
+@pytest.mark.parametrize("password, error_message", [
+    ("short1!", "at least 8 characters"),                            # too short
+    ("alllowercase1!", "uppercase"),                                 # missing uppercase
+    ("ALLUPPERCASE1!", "lowercase"),                                 # missing lowercase
+    ("NoNumbers!", "digit"),                                         # missing digit
+    ("NoSpecial123", "special character")                            # missing special character
+])
+def test_user_create_password_invalid(password, error_message, user_base_data):
+    user_data = {**user_base_data, "password": password}
+    with pytest.raises(ValidationError) as exc_info:
+        UserCreate(**user_data)
+    assert error_message.lower() in str(exc_info.value).lower()


### PR DESCRIPTION
🔧 Fix: #11 
Add a @validator("password") to the UserCreate class that enforces the following rules:

At least 8 characters long

Must contain at least one uppercase letter

Must contain at least one lowercase letter

Must contain at least one digit

Must contain at least one special character